### PR TITLE
Fix typo in sce and sco snippets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# Editor Config File
+# Top-most EditorConfig file
+root = true
+# Rules that apply to all files
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# for shell scripts always use lf line endings
+[*.{sh,bash}]
+end_of_line = lf
+indent_size = 4
+
+# For shell scripts on windows:
+[*.{bat,cmd,ps1}]
+end_of_line = crlf
+
+# Vscode likes json to use tabs typically
+[*.{json,code-workspace}]
+indent_style = tab
+
+# this one has space based indentation
+[package.json]
+indent_style = space
+
+# Build and output files shouldn't use editorconfig
+# Turn off all settings for output files.
+[**/{node_modules,out,dist}/**/*]
+charset = unset
+trim_trailing_whitespace = unset
+indent_style = unset
+indent_size = unset

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - ./ci-install.sh
 
 script:
- - ./ci-build.sh
+  - ./ci-build.sh
 
 notifications:
   email:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cucumber",
-    "version": "0.11.5",
+    "version": "0.12.0",
     "engines": {
         "vscode": "^0.10.0"
     },

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -11,7 +11,7 @@
 		"description": "When Step (Plaintext)",
 		"scope": "text.gherkin.feature"
 	},
-    "giv-rb": {
+	"giv-rb": {
 		"prefix": "giv",
 		"body": "Given ${1:step name} do\r\n  $0\r\nend",
 		"description": "Given Step (Ruby)",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -28,7 +28,8 @@
 		"body": ["Scenario Outline: ${1:title}",
 				"\tGiven ${2:context}",
 				"\tWhen ${3:event}",
-				"\tThen ${4:outcome}"],
+				"\tThen ${4:outcome}\r\n",
+                "$0"],
 		"description": "Scenario Outline",
 		"scope": "text.gherkin.feature"
 	},
@@ -37,7 +38,8 @@
 		"body": ["Scenario: ${1:title}",
 				"\tGiven ${2:context}",
 				"\tWhen ${3:event}",
-				"\tThen ${4:outcome}\r\n$0\r\n$0"],
+				"\tThen ${4:outcome}\r\n",
+                "$0"],
 		"description": "Scenario",
 		"scope": "text.gherkin.feature"
 	},


### PR DESCRIPTION
This fixes a typo in the 'sce' snippet definition that would create
multiple cursors when leaving the scenario It also adds two newlines
after the 'sco' snippet.

This should address issue #23